### PR TITLE
Fix linting error in gatsby-config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -46,7 +46,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-typography',
       options: {
-        pathToConfigModule: 'src/utils/typography.js',
+        pathToConfigModule: 'src/utils/typography.js'
       }
     }
   ]


### PR DESCRIPTION
The comma in the gatsby-config violates [the `prettier` rules](https://github.com/davad/gatsby-hampton-theme/blob/master/.prettierrc#L4)

cc @davad 